### PR TITLE
Configure devdocs platform

### DIFF
--- a/zimfarm/api/api-configs.cm.yaml
+++ b/zimfarm/api/api-configs.cm.yaml
@@ -17,6 +17,7 @@ data:
   PLATFORM_ifixit_MAX_TASKS_PER_WORKER: "1"
   PLATFORM_ifixit_MAX_TASKS_TOTAL: "1"
   PLATFORM_ted_MAX_TASKS_PER_WORKER: "1"
+  PLATFORM_devdocs_MAX_TASKS_PER_WORKER: "1"
   # log and ZIM uploads. log-upload uri in secret (token inside)
   ZIM_UPLOAD_URI: "sftp://uploader@warehouse.farm.openzim.org:30122/zim"
   LOGS_EXPIRATION: "60"


### PR DESCRIPTION
Add a devdocs platform with a limit of 1 per worker, no total limit.