### PR TITLE
Use a custom kiwix-serve index template

### DIFF
--- a/zim/library/backend.yaml
+++ b/zim/library/backend.yaml
@@ -19,10 +19,12 @@ spec:
       # /!\ manually purge kiwix-serve cache on kiwix-serve version upgrade
       # curl -X PURGE -H "X-Purge-Type: kiwix-serve" http://library-frontend-service
       # also check that varnish hack still necessary (gzip, endpoints)
+      # /!\ manually trigger update-kiwixserve-template Job on kiwix-serve upgrade
+      # after having updated the LIBKIWIX_VERSION field in env (and tested!)
       - image: ghcr.io/kiwix/kiwix-tools:3.7.0-1
         imagePullPolicy: IfNotPresent
         name: kiwix-tools
-        args: ["kiwix-serve", "-b", "--library", "--monitorLibrary", "--threads", "16", "--searchLimit", "5", "--nodatealias", "/data/library/internal_library.xml"]
+        args: ["kiwix-serve", "-b", "--library", "--monitorLibrary", "--threads", "16", "--searchLimit", "5", "--nodatealias", "--customIndex", "/data/kiwix-serve-templates/index-template.html", "/data/library/internal_library.xml"]
         ports:
         - containerPort: 80
         livenessProbe:
@@ -41,6 +43,10 @@ spec:
           readOnly: true
         - mountPath: "/data/library/internal_library.xml"
           subPath: internal_library.xml
+          name: library-volume
+          readOnly: true
+        - mountPath: "/data/kiwix-serve-templates"
+          subPath: kiwix-serve-templates
           name: library-volume
           readOnly: true
         resources:

--- a/zim/library/update-kiwixserve-template.job.yaml
+++ b/zim/library/update-kiwixserve-template.job.yaml
@@ -1,0 +1,38 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: update-kiwixserve-template
+  namespace: zim
+spec:
+  backoffLimit: 1
+  template:
+    spec:
+      containers:
+        - name: maintenance
+          image: ghcr.io/kiwix/maintenance:latest
+          imagePullPolicy: Always
+          env:
+          # this must be set according to the libkiwix version that is bundled in the
+          # kiwix-serve version we use in library-data-backend-deployment
+          # can be obtain with `kiwix-serve --version`
+          - name: LIBKIWIX_VERSION
+            value: "14.0.0"
+          - name: INSTALL_SCRIPTS
+            value: "update-template#github://kiwix/operations/zim/library/update-kiwixserve-template.sh\n"
+          volumeMounts:
+          - mountPath: "/data"
+            subPath: kiwix-serve-templates
+            name: library-volume
+            readOnly: false
+          args: ["/usr/local/bin/update-template"]
+          resources:
+            requests:
+              cpu: 200m
+              memory: 1Gi
+      volumes:
+      - name: library-volume
+        persistentVolumeClaim:
+          claimName: kiwix-library-pvc
+      restartPolicy: Never
+      nodeSelector:
+        k8s.kiwix.org/role: "storage"

--- a/zim/library/update-kiwixserve-template.sh
+++ b/zim/library/update-kiwixserve-template.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -e
+
+TEMPLATE_PATH=/data/index-template.html
+TEMPLATE_TMP_PATH="${TEMPLATE_PATH}.tmp"
+TEMPLATE_SRC_PATH="${TEMPLATE_PATH}.src"
+TEMPLATE_URL="https://github.com/kiwix/libkiwix/raw/refs/tags/${LIBKIWIX_VERSION}/static/templates/index.html"
+KIWIX_PATCH=$(cat <<EOF
+*** index.html	2024-10-29 12:16:01
+--- index-kiwix.html	2024-10-29 12:18:18
+***************
+*** 4,10 ****
+      <meta charset="UTF-8" />
+      <meta name="viewport" content="width=device-width,initial-scale=1" />
+      <link type="root" href="{{root}}">
+!     <title>Welcome to Kiwix Server</title>
+      <link
+        type="text/css"
+        href="{{root}}/skin/kiwix.css?KIWIXCACHEID"
+--- 4,10 ----
+      <meta charset="UTF-8" />
+      <meta name="viewport" content="width=device-width,initial-scale=1" />
+      <link type="root" href="{{root}}">
+!     <title>Kiwix Library</title>
+      <link
+        type="text/css"
+        href="{{root}}/skin/kiwix.css?KIWIXCACHEID"
+***************
+*** 39,44 ****
+--- 39,46 ----
+      <script src="{{root}}/skin/isotope.pkgd.min.js?KIWIXCACHEID" defer></script>
+      <script src="{{root}}/skin/iso6391To3.js?KIWIXCACHEID"></script>
+      <script type="text/javascript" src="{{root}}/skin/index.js?KIWIXCACHEID" defer></script>
++     <link rel="stylesheet" type="text/css" href="https://donorbox.org/animate-popup-donate-button.css">
++     <script type="text/javascript" id="donorbox-donate-button-installer" src="https://donorbox.org/install-donate-button.js" data-target="_blank" data-href="https://donorbox.org/kiwix?default_interval=m" data-style="background: rgb(255, 153, 51); color: rgb(255, 255, 255); text-decoration: none; font-family: Verdana, sans-serif; display: flex; font-size: 16px; padding: 8px 22px 8px 18px; border-radius: 5px 5px 0px 0px; gap: 8px; width: fit-content; line-height: 24px; position: fixed; top: 50%; transform-origin: center center; z-index: 9999; overflow: hidden; right: 20px; transform: translate(50%, -50%) rotate(-90deg);" data-button-cta="Support" data-img-src="https://donorbox.org/images/white_logo.svg"></script>
+    </head>
+    <body>
+      <noscript>
+EOF
+)
+
+cleanup() {
+	rm -f $TEMPLATE_TMP_PATH $TEMPLATE_SRC_PATH
+}
+
+echo "Cleaning up…"
+
+cleanup
+
+echo "Downloading source template from libkiwix version ${LIBKIWIX_VERSION}…"
+
+curl -o $TEMPLATE_SRC_PATH -L $TEMPLATE_URL
+
+echo "Applying Kiwix Patch…"
+
+echo "$KIWIX_PATCH" | patch --input=- --output=$TEMPLATE_TMP_PATH -p1 $TEMPLATE_SRC_PATH
+
+echo "Replacing final file…"
+
+mv $TEMPLATE_TMP_PATH $TEMPLATE_PATH
+
+echo "Cleaning up"
+
+cleanup
+
+echo "done."


### PR DESCRIPTION
- Start kiwix-serve with --custom-index option
- Add a Job that creates this index.html from the Github version (pinned version) applying two patches:
  - Changing the title name (yay)
  - Adding the donorbox sticky donate button This jobs is supposed to be ran manually when we change kiwix-serve version

Fixes #295

⚠️ this is already deployed and tested. In live version, job was created targetting script in branch instead.