### PR TITLE
Simplify removal of ZIMs from the library catalog with delete files markers

### DIFF
--- a/zim/library-mgmt/library-maint.py
+++ b/zim/library-mgmt/library-maint.py
@@ -198,9 +198,16 @@ def get_zim_files(
     Optionnaly includes ZIM files in hidden folders (not hidden ZIMs!)"""
 
     def excluded_filter(fp: pathlib.Path) -> bool:
-        """excludes both special patterns and hidden files"""
-        return not fp.name.startswith("speedtest_") and (
-            not fp.name.startswith(".") or fp.name == "."
+        """excludes files not to consider
+
+        - special patterns
+        - hidden files
+        - files marked for deletion with .delete suffix
+        """
+        return (
+            not fp.name.startswith("speedtest_")
+            and (not fp.name.startswith(".") or fp.name == ".")
+            and (len(fp.name) == 0 or not fp.with_suffix(".delete").exists())
         )
 
     if with_hidden:  # faster than os.walk in this case
@@ -687,6 +694,7 @@ class LibraryMaintainer:
 
         if "purge-varnish" in self.actions:
             self.purge_varnish()
+
 
 def entrypoint():
     parser = argparse.ArgumentParser(

--- a/zim/library-mgmt/library-maint.py
+++ b/zim/library-mgmt/library-maint.py
@@ -441,8 +441,8 @@ class LibraryMaintainer:
         entry.update(
             {
                 "id": str(zim.uuid),
-                "mediaCount": str(zim.media_counter),
-                "articleCount": str(zim.article_counter),
+                "mediaCount": str(zim.media_count),
+                "articleCount": str(zim.article_count),
             }
         )
 


### PR DESCRIPTION
Fix #307 

Slightly modified for code simplicity on convention of file name: if `zim/zimit/my_zim.zim` needs to be removed from catalog, one has to "touch" `zim/zimit/my_zim.delete`

NOTA: not yet tested, we cannot run a script from a branch yet (I'm going to import image from rgaudin to kiwix since it is used everywhere, and add feature to retrieve script from a branch ; it would save to have to merge branch only to realize there is a bug and commit again a fix