### PR TITLE
Migrate from rgaudin debian image to kiwix maintenance image

### DIFF
--- a/cluster-mgmt/overview/overview.yaml
+++ b/cluster-mgmt/overview/overview.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       serviceAccountName: cluster-viewer
       containers:
-      - image: ghcr.io/rgaudin/debian:dev
+      - image: ghcr.io/kiwix/maintenance:latest
         imagePullPolicy: Always
         name: script
         # regen every 5mn

--- a/debug/debug.job.yaml
+++ b/debug/debug.job.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: debian
-          image: ghcr.io/rgaudin/debian:dev
+          image: ghcr.io/kiwix/maintenance:latest
           imagePullPolicy: Always
           env:
           - name: ZIM_PATH

--- a/zim/dev-library/dev-library-generator.cronjob.yaml
+++ b/zim/dev-library/dev-library-generator.cronjob.yaml
@@ -15,7 +15,7 @@ spec:
         spec:
           containers:
             - name: debian
-              image: ghcr.io/rgaudin/debian:dev
+              image: ghcr.io/kiwix/maintenance:latest
               imagePullPolicy: Always
               env:
               - name: INSTALL_SCRIPTS

--- a/zim/library-mgmt/library-generator.cronjob.yaml
+++ b/zim/library-mgmt/library-generator.cronjob.yaml
@@ -15,7 +15,7 @@ spec:
         spec:
           containers:
             - name: debian
-              image: ghcr.io/rgaudin/debian:dev
+              image: ghcr.io/kiwix/maintenance:latest
               imagePullPolicy: Always
               env:
               - name: INSTALL_SCRIPTS

--- a/zim/library-mgmt/maintenance.job.yaml
+++ b/zim/library-mgmt/maintenance.job.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       containers:
         - name: debian
-          image: ghcr.io/rgaudin/debian:dev
+          image: ghcr.io/kiwix/maintenance:latest
           imagePullPolicy: Always
           env:
           - name: VARNISH_URL


### PR DESCRIPTION
Nota: this includes a migration from `docker.io/library/python:3.9-slim` to `docker.io/library/python:3.12-bookworm` ; vigilance will be needed when deploying to ensure we do not break something