### PR TITLE
Remove zimit failed task analysis from weekly routine

### DIFF
--- a/.github/workflows/weekly_routine.yaml
+++ b/.github/workflows/weekly_routine.yaml
@@ -110,7 +110,6 @@ jobs:
           - [ ] UptimeRobot [has no alert](https://dashboard.uptimerobot.com/monitors)
           - [ ] [zimit backlog](https://farm.zimit.kiwix.org/pipeline/filter-todo) is reasonable
           - [ ] [Cloud Code Signing Certificate](https://secure.ssl.com/certificate_orders/co-291j8smt34b) usage is *OK* (look for *Unused Signings* under *END ENTITY CERTIFICATES*): we have 1,200 per year (August to August)
-          - [ ] Analyze [zimit failed tasks](https://farm.zimit.kiwix.org/pipeline/filter-failed) and document bad domains in our [WIP blacklist](https://docs.google.com/spreadsheets/d/1mBjWT0hLmeg6EqT4nNEfCzLU8hGSzYs4IgbWDInhPqA/edit?gid=0#gid=0)
           - [ ] [PRs awaiting your review](https://github.com/notifications?query=reason%3Areview-requested)
 
           ## Security


### PR DESCRIPTION
As agreed in our last weekly, I remove the analysis of Zimit failed tasks from our weekly routine, project is ready at https://github.com/orgs/openzim/projects/24